### PR TITLE
Renamed sync.php to Sync.php and updated errorHandler to remove error…

### DIFF
--- a/src/sync.php
+++ b/src/sync.php
@@ -96,9 +96,6 @@ function errorHandler($error) {
     if (!method_exists($error, 'get_code')) {
         print_r($error);
     } else {
-        echo "-------ERROR-------".PHP_EOL;
-        print_r($error->get_response());
-        echo "Code: ".$error->get_code()." Message: ".$error->getMessage().PHP_EOL;
         throw $error;
     }
 } // END errorHandler function


### PR DESCRIPTION
- Cambié el nombre de sync.php a Sync.php para seguir las convenciones de nombres de clases en PHP.

- Eliminé las líneas de salida de mensajes en la función errorHandler para evitar la impresión de errores en pantalla durante la ejecución.

- Esta actualización podría romper la compatibilidad con versiones anteriores, por lo que se ha incrementado la versión a 2.0.0.